### PR TITLE
Change Skeleton3D.get_bone_pose

### DIFF
--- a/addons/vrm/vrm_collidergroup.gd
+++ b/addons/vrm/vrm_collidergroup.gd
@@ -63,7 +63,7 @@ class SphereCollider:
 	func update(parent: Node3D, skel: Object):
 		if parent.get_class() == "Skeleton3D" && idx != -1:
 			var skeleton: Skeleton3D = parent as Skeleton3D
-			position = VRMTopLevel.VRMUtil.transform_point(skeleton.get_global_transform() * skel.get_global_pose(idx), offset)
+			position = VRMTopLevel.VRMUtil.transform_point(skeleton.get_global_transform() * skel.get_bone_global_pose(idx), offset)
 		else:
 			position = VRMTopLevel.VRMUtil.transform_point(parent.global_transform, offset)
 


### PR DESCRIPTION
In Godot 4, the Skeleton3D.get_global_pose() function has been removed. It should be replaced with Skeleton3D.get_bone_global_pose().