### PR TITLE
Fixed dragForce and gravityDir keys in spring bone data.

### DIFF
--- a/addons/vrm/import_vrm.gd
+++ b/addons/vrm/import_vrm.gd
@@ -640,9 +640,9 @@ func _parse_secondary_node(secondary_node: Node, vrm_extension: Dictionary, gsta
 		spring_bone.comment = sbone.get("comment", "")
 		spring_bone.stiffness_force = float(sbone.get("stiffiness", 1.0))
 		spring_bone.gravity_power = float(sbone.get("gravityPower", 0.0))
-		var gravity_dir = sbone.get("gravity_dir", {"x": 0.0, "y": -1.0, "z": 0.0})
+		var gravity_dir = sbone.get("gravityDir", {"x": 0.0, "y": -1.0, "z": 0.0})
 		spring_bone.gravity_dir = Vector3(gravity_dir["x"], gravity_dir["y"], gravity_dir["z"])
-		spring_bone.drag_force = float(sbone.get("drag_force", 0.4))
+		spring_bone.drag_force = float(sbone.get("dragForce", 0.4))
 		spring_bone.hit_radius = float(sbone.get("hitRadius", 0.02))
 		
 		if spring_bone.comment != "":


### PR DESCRIPTION
Spec and example files use camelCase instead of snake_case.