### PR TITLE
Update Git metadata and update project name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.vrm.res
+
 # Godot-specific ignores
 .import/
 .godot/
@@ -6,7 +8,11 @@ export_presets.cfg
 
 # Imported translations (automatically generated from CSV files)
 *.translation
-*.vrm.res
+
 # Mono-specific ignores
 .mono/
 data_*/
+
+# System/tool-specific ignores
+.DS_Store
+*~

--- a/addons/vrm/plugin.gd
+++ b/addons/vrm/plugin.gd
@@ -4,11 +4,13 @@ extends EditorPlugin
 var import_plugin
 
 
-func _enter_tree():
+func _enter_tree() -> void:
+	# NOTE: Be sure to also register at runtime if you want runtime import.
+	# This editor plugin script won't run outside of the editor.
 	import_plugin = preload("res://addons/vrm/import_vrm.gd").new()
 	add_scene_format_importer_plugin(import_plugin)
 
 
-func _exit_tree():
+func _exit_tree() -> void:
 	remove_scene_format_importer_plugin(import_plugin)
 	import_plugin = null

--- a/project.godot
+++ b/project.godot
@@ -10,7 +10,7 @@ config_version=5
 
 [application]
 
-config/name="VRM Project [GODOT Master Branch]"
+config/name="VRM Project (Godot 4.x)"
 run/main_scene="res://vrm_samples/sample_scene.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.png"
@@ -18,7 +18,6 @@ enabled=PackedStringArray("vrm")
 
 [display]
 
-window/size/resizable=false
 window/size/width=1920
 window/size/height=1080
 window/size/test_width=1280


### PR DESCRIPTION
This PR updates the Git repo metadata, since I was experiencing `.DS_Store` diffs on my Mac, and I also threw in a `.gitattributes` file to ensure line endings are correct.

This PR also makes the window resizable and updates the project.godot name (4.x not master) and adds a comment about how the editor plugin will not run at runtime.