### PR TITLE
Fix node constraint posing and initialization order

### DIFF
--- a/addons/vrm/1.0/VRMC_node_constraint.gd
+++ b/addons/vrm/1.0/VRMC_node_constraint.gd
@@ -24,19 +24,19 @@ func _import_post_parse(gltf_state: GLTFState) -> Error:
 	var applier: bone_node_constraint_applier = bone_node_constraint_applier.new()
 	applier.name = &"BoneNodeConstraintApplier"
 	gltf_state.set_additional_data(&"BoneNodeConstraintApplier", applier)
-	# Add the constraint applier to the real root, next to the AnimationPlayer.
-	var gltf_root: Node = gltf_state.get_scene_node(gltf_state.root_nodes[0])
-	var real_root = gltf_root.get_parent()
-	real_root.add_child(applier)
-	applier.owner = real_root
 	return OK
 
 
-func _import_post(gstate: GLTFState, node: Node) -> Error:
-	var nodes: Array = gstate.nodes
-	var json_nodes: Array = gstate.json["nodes"]
+func _import_post(gltf_state: GLTFState, root: Node) -> Error:
+	# Add the constraint applier to the real root, next to the AnimationPlayer.
+	var applier: BoneNodeConstraintApplier = gltf_state.get_additional_data(&"BoneNodeConstraintApplier")
+	root.add_child(applier)
+	applier.owner = root
+	# Set up the constraints.
+	var nodes: Array = gltf_state.nodes
+	var json_nodes: Array = gltf_state.json["nodes"]
 	for i in range(len(nodes)):
-		var err: Error = my_import_node(gstate, nodes[i], json_nodes[i], gstate.get_scene_node(i))
+		var err: Error = my_import_node(gltf_state, nodes[i], json_nodes[i], gltf_state.get_scene_node(i))
 		if err != OK:
 			return err
 	return OK

--- a/addons/vrm/node_constraint/bone_node_constraint.gd
+++ b/addons/vrm/node_constraint/bone_node_constraint.gd
@@ -161,7 +161,8 @@ func _get_posed_source_transform() -> Transform3D:
 	if source_bone_index == -1:
 		return source_rest_transform.affine_inverse() * source_node.transform
 	var skeleton: Skeleton3D = source_node as Skeleton3D
-	return skeleton.get_bone_pose(source_bone_index)
+	var rest_inverse: Transform3D = skeleton.get_bone_rest(source_bone_index).affine_inverse()
+	return rest_inverse * skeleton.get_bone_pose(source_bone_index)
 
 
 func _get_source_global_transform() -> Transform3D:
@@ -187,7 +188,8 @@ func _set_weighted_posed_target_rotation(rotation_quat: Quaternion) -> void:
 		target_node.quaternion = rest_quat * rotation_quat
 		return
 	var skeleton: Skeleton3D = target_node as Skeleton3D
-	skeleton.set_bone_pose_rotation(target_bone_index, rotation_quat)
+	var rest_quat: Quaternion = target_rest_transform.basis.get_rotation_quaternion()
+	skeleton.set_bone_pose_rotation(target_bone_index, rest_quat * rotation_quat)
 
 
 func _set_weighted_global_target_rotation(rotation_quat: Quaternion) -> void:


### PR DESCRIPTION
This PR has 2 fixes:

* Fix node constraint posing. I did not realize Godot's skeleton pose did not apply on top of rest, and I ran into incorrect behavior once I tried using a rotation constraint on my taur, a non-trivial case which requires posing bones with rotations that do not start out aligned with the constraint's source. See the below video.
* Fix initialization order, so that we are only adding the node to the tree after the nodes have been generated (`_import_post`) instead of after the GLTF data has been parsed (`_import_post_parse`). This fix is required in Godot 4.2 after https://github.com/godotengine/godot/pull/80272, but it still works in Godot 4.1.

I have tested this with my taur model in this VRM project on Godot 4.1.1 and a build of the Godot master branch (from after 4.2 beta 1).

[pose.webm](https://github.com/V-Sekai/godot-vrm/assets/1646875/294513ba-533e-4f50-9fab-aad7646ef8c8)
