### PR TITLE
Fixed an issue with GLTF images being referenced directly instead of going through the GLTFState.textures mapping.

### DIFF
--- a/addons/vrm/1.0/VRMC_materials_mtoon.gd
+++ b/addons/vrm/1.0/VRMC_materials_mtoon.gd
@@ -267,21 +267,23 @@ func _export_post(state: GLTFState) -> Error:
 	return OK
 
 
-func _vrm_get_texture_info(gltf_images: Array, vrm_mat_props: Dictionary, unity_tex_name: String) -> Dictionary:
+func _vrm_get_texture_info(gstate : GLTFState, vrm_mat_props: Dictionary, unity_tex_name: String) -> Dictionary:
+	var gltf_images: Array = gstate.get_images()
+	var gltf_textures: Array = gstate.get_textures()
 	var texture_info: Dictionary = {}
 	texture_info["tex"] = null
 	texture_info["offset"] = Vector3(0.0, 0.0, 0.0)
 	texture_info["scale"] = Vector3(1.0, 1.0, 1.0)
 	if vrm_mat_props["textureProperties"].has(unity_tex_name):
 		var mainTexId: int = vrm_mat_props["textureProperties"][unity_tex_name]
-		var mainTexImage: Texture2D = gltf_images[mainTexId]
+		var mainTexImageId = gltf_textures[mainTexId].src_image
+		var mainTexImage: Texture2D = gltf_images[mainTexImageId]
 		texture_info["tex"] = mainTexImage
 	if vrm_mat_props["vectorProperties"].has(unity_tex_name):
 		var offsetScale: Array = vrm_mat_props["vectorProperties"][unity_tex_name]
 		texture_info["offset"] = Vector3(offsetScale[0], offsetScale[1], 0.0)
 		texture_info["scale"] = Vector3(offsetScale[2], offsetScale[3], 1.0)
 	return texture_info
-
 
 func _vrm_get_float(vrm_mat_props: Dictionary, key: String, def: float) -> float:
 	return vrm_mat_props["floatProperties"].get(key, def)


### PR DESCRIPTION
The GLTFState.textures list remaps texture IDs to actual image sources. Existing code in _vrm_get_texture_info just used image IDs directly instead, which do not always correspond directly to texture IDs.

This caused texture mis-matches on some VRMs when loaded.

Can provide an example broken model on request. This popped up when I tried using the Blender VRM exporter ( https://vrm-addon-for-blender.info/en/ ), and had one material using the Principled BSDF shader with the rest using MToon. All MToon materials after the Principled BSDF one in the materials list had borked texture mappings.

I had to pass the GLTF state into a few more functions, replacing the image list, so we could also access the textures mapping directly alongside them.
