### PR TITLE
Improve VRMSpringBone performance

### DIFF
--- a/addons/vrm/vrm_secondary.gd
+++ b/addons/vrm/vrm_secondary.gd
@@ -185,6 +185,9 @@ func tick_spring_bones(delta: float) -> void:
 
 	update_centers(skel_transform)
 
+	for spring_i in range(len(spring_bones_internal)):
+		spring_bones_internal[spring_i].pre_update()
+	
 	for collider_i in range(len(colliders_internal)):
 		colliders_internal[collider_i].update(skel_transform, center_transforms[colliders_centers[collider_i]], skel)
 	for spring_i in range(len(spring_bones_internal)):

--- a/addons/vrm/vrm_spring_bone.gd
+++ b/addons/vrm/vrm_spring_bone.gd
@@ -87,6 +87,9 @@ func ready(ready_skel: Skeleton3D, colliders_ref: Array[vrm_collider.VrmRuntimeC
 	setup(center_transform_inv)
 	colliders = colliders_ref.duplicate(false)
 
+func pre_update():
+	for i in range(len(verlets)):
+		verlets[i].pre_update(skel)
 
 func update(delta: float, center_transform: Transform3D, center_transform_inv: Transform3D) -> void:
 	if verlets.is_empty():

--- a/addons/vrm/vrm_spring_bone_logic.gd
+++ b/addons/vrm/vrm_spring_bone_logic.gd
@@ -14,6 +14,7 @@ var current_tail: Vector3
 var prev_tail: Vector3
 
 var initial_transform: Transform3D
+var global_pose: Transform3D
 
 
 static func from_to_rotation_safe(from: Vector3, to: Vector3) -> Quaternion:
@@ -34,6 +35,14 @@ func get_local_pose_rotation(skel: Skeleton3D) -> Quaternion:
 	return get_global_pose(skel).basis.get_rotation_quaternion()
 
 
+func get_global_pose_cached() -> Transform3D:
+	return global_pose
+
+
+func get_local_pose_rotation_cached() -> Quaternion:
+	return global_pose.basis.get_rotation_quaternion()
+
+
 func reset(skel: Skeleton3D) -> void:
 	skel.set_bone_global_pose_override(bone_idx, initial_transform, 1.0, true)
 
@@ -49,15 +58,22 @@ func _init(skel: Skeleton3D, idx: int, center_transform_inv: Transform3D, local_
 	length = local_child_position.length()
 
 
+func pre_update(skel: Skeleton3D) -> void:
+	global_pose = get_global_pose(skel)
+
+
 func update(skel: Skeleton3D, center_transform: Transform3D, center_transform_inv: Transform3D, stiffness_force: float, drag_force: float, external: Vector3, colliders: Array[vrm_collider.VrmRuntimeCollider]) -> void:
 	var tmp_current_tail: Vector3 = current_tail
 	var tmp_prev_tail: Vector3 = prev_tail
-	var global_pose_tr: Transform3D = get_global_pose(skel)
+	var global_pose_tr: Transform3D = get_global_pose_cached()
+	var local_pose_rotation: Quaternion = get_local_pose_rotation_cached()
+	#var global_pose_tr: Transform3D = get_global_pose(skel)
+	#var local_pose_rotation: Quaternion = get_local_pose_rotation(skel)
 
 	var tmp_external: Vector3 = center_transform * external
 
 	# Integration of velocity verlet
-	var next_tail: Vector3 = tmp_current_tail + (tmp_current_tail - tmp_prev_tail) * (1.0 - drag_force) + center_transform.basis.get_rotation_quaternion() * (get_local_pose_rotation(skel) * bone_axis * stiffness_force + external)
+	var next_tail: Vector3 = tmp_current_tail + (tmp_current_tail - tmp_prev_tail) * (1.0 - drag_force) + center_transform.basis.get_rotation_quaternion() * (local_pose_rotation * bone_axis * stiffness_force + external)
 
 	# Limiting bone length
 	var origin: Vector3 = center_transform * global_pose_tr.origin
@@ -77,9 +93,9 @@ func update(skel: Skeleton3D, center_transform: Transform3D, center_transform_in
 	current_tail = next_tail  # center_transform_inv * next_tail
 
 	# Apply rotation
-	var ft = from_to_rotation_safe(get_local_pose_rotation(skel) * (bone_axis), center_transform_inv.basis * (next_tail - origin))
+	var ft = from_to_rotation_safe(local_pose_rotation * (bone_axis), center_transform_inv.basis * (next_tail - origin))
 	if typeof(ft) != TYPE_NIL:
 		# ft = skel.global_transform.basis.get_rotation_quaternion().inverse() * ft
-		var qt: Quaternion = ft * get_local_pose_rotation(skel)
+		var qt: Quaternion = ft * local_pose_rotation
 		global_pose_tr.basis = Basis(qt)
 		skel.set_bone_global_pose_override(bone_idx, global_pose_tr, 1.0, true)


### PR DESCRIPTION
This PR improves SpringBone performance by preforming get_global_pose().
When I try this, the performance is 10x and the behavior appears to be the same.

![compare](https://github.com/V-Sekai/godot-vrm/assets/1732153/b1d1804a-13b1-4616-a024-bf6f2b499899)

## Details

I have noticed that when I place a few VRMs output by VRoidStudio in a Godot scene, the behavior becomes very slow.
When measured in Profiler, get_global_pose() showed a high load, but this seemed to be a load within the Engine.

After checking the code in `vrm_sprint_bone.gd` and [Skeleton3D](https://github.com/godotengine/godot/blob/master/scene/3d/skeleton_3d.cpp), i found that the following process was repeated I found that the following process is repeated.

1. Call Skeleton3D::set_bone_global_pose_override() (This marks the bone as having undergone a change)
2. Call Skeleton3D::get_bone_global_pose(). (NOTIFICATION_UPDATE_SKELETON is notified and force_update_all_bone_transforms() is performed)

This will probably be done for a number of SpringBone vertlets.

So I thought I could reduce this process by calling get_global_pose() on all vertlets in advance and remembering them.
However, the update iteration changes a bit, which may affect the results.