### PR TITLE
Fixed _SphereAdd/_MatcapColor regression in VRM 0.0 introduced in 9aa991f .

### DIFF
--- a/addons/Godot-MToon-Shader/mtoon_common.gdshaderinc
+++ b/addons/Godot-MToon-Shader/mtoon_common.gdshaderinc
@@ -269,7 +269,7 @@ void fragment() {
 	vec3 viewCameraUp = vec3(0.0,1.0,0.0);//normalize(INV_VIEW_MATRIX[1].xyz); // FIXME!!
 	vec3 viewViewUp = normalize(viewCameraUp - viewView * dot(viewView, viewCameraUp));
 	vec3 viewViewRight = normalize(cross(viewView, viewViewUp));
-	vec2 matcapUv = vec2(-dot(viewViewRight, viewNormal), dot(viewViewUp, viewNormal)) * 0.5 + 0.5;
+	vec2 matcapUv = vec2(-dot(viewViewRight, viewNormal), -dot(viewViewUp, viewNormal)) * 0.5 + 0.5;
 	vec3 matcapLighting = _MatcapColor.rgb * texture(_SphereAdd, matcapUv).rgb;
 
 	rim = (rim + matcapLighting) * texture(_RimTexture, mainUv).rgb;

--- a/addons/vrm/vrm_extension.gd
+++ b/addons/vrm/vrm_extension.gd
@@ -193,6 +193,11 @@ func _process_vrm_material(orig_mat: Material, gstate: GLTFState, vrm_mat_props:
 			if outline_mat != null:
 				outline_mat.set_shader_parameter(param_name, tex_info["tex"])
 
+			if param_name == "_SphereAdd":
+				new_mat.set_shader_parameter("_MatcapColor", Vector4(1.0, 1.0, 1.0, 1.0))
+				if outline_mat != null:
+					outline_mat.set_shader_parameter("_MatcapColor", Vector4(1.0, 1.0, 1.0, 1.0))
+
 	for param_name in vrm_mat_props["floatProperties"]:
 		new_mat.set_shader_parameter(param_name, vrm_mat_props["floatProperties"][param_name])
 		if outline_mat != null:


### PR DESCRIPTION
Breaking commit: https://github.com/V-Sekai/godot-vrm/commit/9aa991f3dae34c5231c121be7f57de5b7e10d77f

_MatcapColor was added to the MToon shader, which multiplies against the color from _SphereAdd, without adding any way for the VRM 0.0 loader to set it to something other than the default value of vec4(0.0, 0.0, 0.0, 1.0), meaning that it would always have zero additive influence.

This commit also flips the vertical axis of matcapUv in the MToon shader, because the _SphereAdd texture was showing up inverted in Godot.