### PR TITLE
Fixed _MatcapColor not getting saved on editor-imported VRMs.

### DIFF
--- a/addons/vrm/vrm_extension.gd
+++ b/addons/vrm/vrm_extension.gd
@@ -194,9 +194,9 @@ func _process_vrm_material(orig_mat: Material, gstate: GLTFState, vrm_mat_props:
 				outline_mat.set_shader_parameter(param_name, tex_info["tex"])
 
 			if param_name == "_SphereAdd":
-				new_mat.set_shader_parameter("_MatcapColor", Vector4(1.0, 1.0, 1.0, 1.0))
+				new_mat.set_shader_parameter("_MatcapColor", Color(1.0, 1.0, 1.0, 1.0))
 				if outline_mat != null:
-					outline_mat.set_shader_parameter("_MatcapColor", Vector4(1.0, 1.0, 1.0, 1.0))
+					outline_mat.set_shader_parameter("_MatcapColor", Color(1.0, 1.0, 1.0, 1.0))
 
 	for param_name in vrm_mat_props["floatProperties"]:
 		new_mat.set_shader_parameter(param_name, vrm_mat_props["floatProperties"][param_name])


### PR DESCRIPTION
Got another one for that _MatcapColor fix for VRM 0.0 models. In my original fix it used a Vector4 type as a color, which worked fine for previewing in the import window and doing runtime imports, but some part of the post-import process was ignoring anything that wasn't a Color type in that field, and was failing to save it to the actual output scene.

This just changes the type of the variable to Color. Now it works consistently for imported meshes, runtime meshes, and the preview window.
