### PR TITLE
Remove dead code in vrm_secondary.gd

### DIFF
--- a/addons/vrm/vrm_secondary.gd
+++ b/addons/vrm/vrm_secondary.gd
@@ -277,8 +277,6 @@ func tick_spring_bones(delta: float) -> void:
 	# our setter syncs it the other direction.
 	if is_child_of_vrm:
 		var parent: Node = get_parent()
-	var parent: Node = get_parent()
-	if is_child_of_vrm:
 		if parent.springbone_gravity_rotation != springbone_gravity_rotation or parent.springbone_gravity_multiplier != springbone_gravity_multiplier or parent.springbone_add_force != springbone_add_force:
 			springbone_add_force = parent.springbone_add_force
 			springbone_gravity_rotation = parent.springbone_gravity_rotation


### PR DESCRIPTION
I was browsing the code and noticed this bit of code that appeared unnecessary. I'm pretty sure the branch that only does `var parent: Node = get_parent()` is doesn't do anything meaningful, and `parent` is only used in the following branch, so there appears no reason why it should be declared outside. Maybe this is the result of some refactoring?

It's a tiny change but I figured I'd make a quick PR anyway.
Feel free to close and apply the change manually as well.