### PR TITLE
fix to gitattributes to exclude unnecessary files in asset library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
this should exclude all files outside the addons folder when the asset library bundles the addon.

[this issue](https://github.com/V-Sekai/godot-vrm/issues/98) should be fixed by this now 