### PR TITLE
Fix VRM 1.0 spring-bone import: read spec key `stiffness`, not 0.x typo `stiffiness`

### DIFF
--- a/addons/vrm/1.0/VRMC_springBone.gd
+++ b/addons/vrm/1.0/VRMC_springBone.gd
@@ -122,7 +122,10 @@ func _parse_secondary_node(secondary_node: Node, vrm_extension: Dictionary, gsta
 		for sjoint in sbone["joints"]:
 			spring_bone.hit_radius.append(float(sjoint.get("hitRadius", 0.0)))
 			spring_bone.hit_radius_scale = max(spring_bone.hit_radius_scale, spring_bone.hit_radius[-1])
-			spring_bone.stiffness_force.append(float(sjoint.get("stiffiness", 1.0)))
+			# VRM 1.0 spec key is "stiffness"; fall back to the 0.x-era "stiffiness"
+			# typo so any files mistakenly authored with it still load. (The
+			# exporter at the bottom of this file already writes "stiffness".)
+			spring_bone.stiffness_force.append(float(sjoint.get("stiffness", sjoint.get("stiffiness", 1.0))))
 			spring_bone.stiffness_scale = max(spring_bone.stiffness_scale, spring_bone.stiffness_force[-1])
 			spring_bone.gravity_power.append(float(sjoint.get("gravityPower", 0.0)))
 			spring_bone.gravity_scale = max(spring_bone.gravity_scale, spring_bone.gravity_power[-1])


### PR DESCRIPTION
## What

Fixes the VRM **1.0** spring-bone importer reading the misspelled key `"stiffiness"` (the VRM 0.x `secondaryAnimation` field name) instead of the VRM 1.0 spec key `"stiffness"`. Today every VRM 1.0 spring joint silently ignores its authored stiffness and runs at the default `1.0` (max).

`addons/vrm/1.0/VRMC_springBone.gd`:

```diff
-			spring_bone.stiffness_force.append(float(sjoint.get("stiffiness", 1.0)))
+			spring_bone.stiffness_force.append(float(sjoint.get("stiffness", sjoint.get("stiffiness", 1.0))))
```

Reads the spec key `stiffness` first, falling back to the legacy `stiffiness` typo so any files mistakenly authored with it still load.

## Why it's clearly a typo

The **exporter** in this same file already writes the spec-correct key (`joint["stiffness"] = stiffness`). So godot **exports** `stiffness` but **imports** `stiffiness` — a spec-compliant 1.0 file loses its stiffness on import, and a model round-tripped through godot has its stiffness silently reset to `1.0`.

The `stiffiness` spelling is canonical only in VRM **0.x** `secondaryAnimation` (`vrm_extension.gd`), which is unchanged here.

## Testing

Verified the field is now read on import. Found while building a cross-renderer VRM 1.0 conformance suite — godot's spring chains ran stiffer than UniVRM / three-vrm / VRMMetalKit on the same `VRMC_springBone` assets, traced to this dropped `stiffness`.

Draft pending a maintainer's preference on the fallback (read `stiffness` only, vs the `stiffness`-then-`stiffiness` fallback used here).

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
