### PR TITLE
Return values from GLTFDocumentExtension overrides for Godot 4.7

### DIFF
--- a/addons/vrm/1.0/VRMC_materials_hdr_emissiveMultiplier.gd
+++ b/addons/vrm/1.0/VRMC_materials_hdr_emissiveMultiplier.gd
@@ -21,6 +21,7 @@ func _import_post(state, root):
 				material.emission_energy_multiplier = khr_emissive["emissiveStrength"]
 			elif vrmc_emissive.has("emissiveMultiplier"):
 				material.emission_energy_multiplier = vrmc_emissive["emissiveMultiplier"]
+	return OK
 
 
 func _export(state: GLTFState, extensions = PackedStringArray()) -> Error:
@@ -43,3 +44,4 @@ func _export_post(state: GLTFState):
 				json_material["extensions"]["KHR_materials_emissive_strength"] = {
 					"emissiveStrength": material.emission_energy_multiplier,
 				}
+	return OK

--- a/addons/vrm/1.0/VRMC_materials_mtoon.gd
+++ b/addons/vrm/1.0/VRMC_materials_mtoon.gd
@@ -519,3 +519,4 @@ func _import_post(gstate, root):
 				printerr("Mesh " + str(i) + " material " + str(surf_idx) + " name " + str(surfmat.resource_name) + " has no replacement material.")
 
 	# FIXME: due to head duplication, do we now have some meshes which are not in gltf state?
+	return OK

--- a/addons/vrm/1.0/VRMC_springBone.gd
+++ b/addons/vrm/1.0/VRMC_springBone.gd
@@ -434,3 +434,4 @@ func _export_post(state: GLTFState):
 		json_springs.push_back(spring)
 	sbone_extension["springs"] = json_springs
 	sbone_extension["specVersion"] = "1.0"
+	return OK


### PR DESCRIPTION
Godot 4.7 enforces the Error return type of GLTFDocumentExtension virtuals, so the _import_post/_export_post overrides that fell through without returning fail to compile. That cascades to plugin.gd and leaves the VRM extensions unregistered, so VRM files import as plain glTF. Add the missing return OK.