### PR TITLE
Add UID files. This will conflict with all projects. Use a clean repo.

### DIFF
--- a/addons/Godot-MToon-Shader/inspector_mtoon.gd.uid
+++ b/addons/Godot-MToon-Shader/inspector_mtoon.gd.uid
@@ -1,0 +1,1 @@
+uid://mtooncurowps4

--- a/addons/Godot-MToon-Shader/mtoon.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonyph8u0at

--- a/addons/Godot-MToon-Shader/mtoon_common.gdshaderinc.uid
+++ b/addons/Godot-MToon-Shader/mtoon_common.gdshaderinc.uid
@@ -1,0 +1,1 @@
+uid://mtoon36ssv0f

--- a/addons/Godot-MToon-Shader/mtoon_cull_off.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_cull_off.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonqwuvq5yu

--- a/addons/Godot-MToon-Shader/mtoon_cutout.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_cutout.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonej738gao

--- a/addons/Godot-MToon-Shader/mtoon_cutout_cull_off.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_cutout_cull_off.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoon6qvvh5ux

--- a/addons/Godot-MToon-Shader/mtoon_outline.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_outline.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonvy1rojo8

--- a/addons/Godot-MToon-Shader/mtoon_outline_cutout.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_outline_cutout.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonnkm7354c

--- a/addons/Godot-MToon-Shader/mtoon_outline_trans.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_outline_trans.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonod51gruh

--- a/addons/Godot-MToon-Shader/mtoon_outline_trans_zwrite.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_outline_trans_zwrite.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonkeupqcgu

--- a/addons/Godot-MToon-Shader/mtoon_trans.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_trans.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonf60ve5np

--- a/addons/Godot-MToon-Shader/mtoon_trans_cull_off.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_trans_cull_off.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonabwu3vqk

--- a/addons/Godot-MToon-Shader/mtoon_trans_zwrite.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_trans_zwrite.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtooni5jsbk7

--- a/addons/Godot-MToon-Shader/mtoon_trans_zwrite_cull_off.gdshader.uid
+++ b/addons/Godot-MToon-Shader/mtoon_trans_zwrite_cull_off.gdshader.uid
@@ -1,0 +1,1 @@
+uid://mtoonyu4aoyn

--- a/addons/Godot-MToon-Shader/plugin.gd.uid
+++ b/addons/Godot-MToon-Shader/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://mtoon6pvsd2f

--- a/addons/vrm/1.0/VRMC_materials_hdr_emissiveMultiplier.gd.uid
+++ b/addons/vrm/1.0/VRMC_materials_hdr_emissiveMultiplier.gd.uid
@@ -1,0 +1,1 @@
+uid://vrm1ao3q1m22s

--- a/addons/vrm/1.0/VRMC_materials_mtoon.gd.uid
+++ b/addons/vrm/1.0/VRMC_materials_mtoon.gd.uid
@@ -1,0 +1,1 @@
+uid://vrm1ya450obk6

--- a/addons/vrm/1.0/VRMC_node_constraint.gd.uid
+++ b/addons/vrm/1.0/VRMC_node_constraint.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmpuisb7surs

--- a/addons/vrm/1.0/VRMC_springBone.gd.uid
+++ b/addons/vrm/1.0/VRMC_springBone.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmcfncsv63u4

--- a/addons/vrm/1.0/VRMC_vrm.gd.uid
+++ b/addons/vrm/1.0/VRMC_vrm.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmbp2hbui7nr

--- a/addons/vrm/1.0/VRMC_vrm_animation.gd.uid
+++ b/addons/vrm/1.0/VRMC_vrm_animation.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmi5e0wk3sh8

--- a/addons/vrm/import_vrm.gd.uid
+++ b/addons/vrm/import_vrm.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmbk6q1tafu

--- a/addons/vrm/importer_mesh_attributes.gd.uid
+++ b/addons/vrm/importer_mesh_attributes.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmberajv7d5h

--- a/addons/vrm/node_constraint/bone_node_constraint.gd.uid
+++ b/addons/vrm/node_constraint/bone_node_constraint.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmj1pbn83i5f

--- a/addons/vrm/node_constraint/bone_node_constraint_applier.gd.uid
+++ b/addons/vrm/node_constraint/bone_node_constraint_applier.gd.uid
@@ -1,0 +1,1 @@
+uid://vrm51qxclb0gr

--- a/addons/vrm/plugin.gd.uid
+++ b/addons/vrm/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://vrma2mdmvjemf

--- a/addons/vrm/vrm_collider.gd.uid
+++ b/addons/vrm/vrm_collider.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmgkyemjwmkb

--- a/addons/vrm/vrm_collider_group.gd.uid
+++ b/addons/vrm/vrm_collider_group.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmy3kjfrii5

--- a/addons/vrm/vrm_constants.gd.uid
+++ b/addons/vrm/vrm_constants.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmsa3xuph13

--- a/addons/vrm/vrm_extension.gd.uid
+++ b/addons/vrm/vrm_extension.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmy2emuug1y

--- a/addons/vrm/vrm_meta.gd.uid
+++ b/addons/vrm/vrm_meta.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmapknmnpjv4

--- a/addons/vrm/vrm_options_post_import_plugin.gd.uid
+++ b/addons/vrm/vrm_options_post_import_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmiwbi1d65lq

--- a/addons/vrm/vrm_secondary.gd.uid
+++ b/addons/vrm/vrm_secondary.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmq73ifyk61

--- a/addons/vrm/vrm_spring_bone.gd.uid
+++ b/addons/vrm/vrm_spring_bone.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmvdcldap0m

--- a/addons/vrm/vrm_spring_bone_logic.gd.uid
+++ b/addons/vrm/vrm_spring_bone_logic.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmconcxpap23

--- a/addons/vrm/vrm_toplevel.gd.uid
+++ b/addons/vrm/vrm_toplevel.gd.uid
@@ -1,0 +1,1 @@
+uid://vrm5qsyg2fbbq

--- a/addons/vrm/vrm_utils.gd.uid
+++ b/addons/vrm/vrm_utils.gd.uid
@@ -1,0 +1,1 @@
+uid://vrm1xifpgn7e

--- a/vrm_samples/load_at_runtime_scene.gd.uid
+++ b/vrm_samples/load_at_runtime_scene.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmsamplenwje

--- a/vrm_samples/sample_script.gd.uid
+++ b/vrm_samples/sample_script.gd.uid
@@ -1,0 +1,1 @@
+uid://vrmsamplemwak


### PR DESCRIPTION
Added new UID files. They have "mtoon" or "vrm" in them to make it easy to resolve merge conflicts with the canonically correct UID.

Every Godot project currently using godot-vrm or MToon will have *already generated* .gd.uid, .gdshaderinc.uid and .gdshader.uid files. Migrating projects to use standard UID files will take some work.