### PR TITLE
Add Embedded Image Handling import option

### DIFF
--- a/addons/vrm/import_vrm.gd
+++ b/addons/vrm/import_vrm.gd
@@ -35,8 +35,7 @@ func _import_scene(path: String, flags: int, options: Dictionary) -> Object:
 	state.set_additional_data(&"vrm/head_hiding_method", options.get(&"vrm/head_hiding_method", 0) as vrm_constants.HeadHidingSetting)
 	state.set_additional_data(&"vrm/first_person_layers", options.get(&"vrm/only_if_head_hiding_uses_layers/first_person_layers", 2) as int)
 	state.set_additional_data(&"vrm/third_person_layers", options.get(&"vrm/only_if_head_hiding_uses_layers/third_person_layers", 4) as int)
-	# HANDLE_BINARY_EMBED_AS_BASISU crashes on some files in 4.0 and 4.1
-	state.handle_binary_image = GLTFState.HANDLE_BINARY_EMBED_AS_UNCOMPRESSED  # GLTFState.HANDLE_BINARY_EXTRACT_TEXTURES
+	state.handle_binary_image = options.get(&"vrm/embedded_image_handling", GLTFState.HandleBinaryImageMode.HANDLE_BINARY_IMAGE_MODE_EMBED_AS_BASISU) as GLTFState.HandleBinaryImageMode
 	var err = gltf.append_from_file(path, state, flags)
 	if err != OK:
 		gltf.unregister_gltf_document_extension(vrm_extension)

--- a/addons/vrm/import_vrm.gd
+++ b/addons/vrm/import_vrm.gd
@@ -35,7 +35,7 @@ func _import_scene(path: String, flags: int, options: Dictionary) -> Object:
 	state.set_additional_data(&"vrm/head_hiding_method", options.get(&"vrm/head_hiding_method", 0) as vrm_constants.HeadHidingSetting)
 	state.set_additional_data(&"vrm/first_person_layers", options.get(&"vrm/only_if_head_hiding_uses_layers/first_person_layers", 2) as int)
 	state.set_additional_data(&"vrm/third_person_layers", options.get(&"vrm/only_if_head_hiding_uses_layers/third_person_layers", 4) as int)
-	state.handle_binary_image = options.get(&"vrm/embedded_image_handling", GLTFState.HandleBinaryImageMode.HANDLE_BINARY_IMAGE_MODE_EMBED_AS_BASISU) as GLTFState.HandleBinaryImageMode
+	state.handle_binary_image = options.get(&"vrm/embedded_image_handling", GLTFState.HandleBinaryImageMode.HANDLE_BINARY_IMAGE_MODE_EMBED_AS_UNCOMPRESSED) as GLTFState.HandleBinaryImageMode
 	var err = gltf.append_from_file(path, state, flags)
 	if err != OK:
 		gltf.unregister_gltf_document_extension(vrm_extension)

--- a/addons/vrm/vrm_options_post_import_plugin.gd
+++ b/addons/vrm/vrm_options_post_import_plugin.gd
@@ -5,6 +5,9 @@ signal foo
 
 func _get_import_options(path: String):
 	if path.is_empty() or path.get_extension().to_lower() == "vrm":
+		add_import_option_advanced(TYPE_INT, "vrm/embedded_image_handling",
+			GLTFState.HandleBinaryImageMode.HANDLE_BINARY_IMAGE_MODE_EMBED_AS_BASISU, PROPERTY_HINT_ENUM,
+			"Discard All Textures,Extract Textures,Embed as Basis Universal,Embed as Uncompressed")
 		add_import_option_advanced(TYPE_INT, "vrm/head_hiding_method", 0, PROPERTY_HINT_ENUM,
 			"ThirdPersonOnly,FirstPersonOnly,FirstWithShadow,Layers,LayersWithShadow,IgnoreHeadHiding")
 		add_import_option_advanced(TYPE_INT, "vrm/only_if_head_hiding_uses_layers/first_person_layers", 2, PROPERTY_HINT_LAYERS_3D_RENDER)

--- a/addons/vrm/vrm_options_post_import_plugin.gd
+++ b/addons/vrm/vrm_options_post_import_plugin.gd
@@ -6,7 +6,7 @@ signal foo
 func _get_import_options(path: String):
 	if path.is_empty() or path.get_extension().to_lower() == "vrm":
 		add_import_option_advanced(TYPE_INT, "vrm/embedded_image_handling",
-			GLTFState.HandleBinaryImageMode.HANDLE_BINARY_IMAGE_MODE_EMBED_AS_BASISU, PROPERTY_HINT_ENUM,
+			GLTFState.HandleBinaryImageMode.HANDLE_BINARY_IMAGE_MODE_EMBED_AS_UNCOMPRESSED, PROPERTY_HINT_ENUM,
 			"Discard All Textures,Extract Textures,Embed as Basis Universal,Embed as Uncompressed")
 		add_import_option_advanced(TYPE_INT, "vrm/head_hiding_method", 0, PROPERTY_HINT_ENUM,
 			"ThirdPersonOnly,FirstPersonOnly,FirstWithShadow,Layers,LayersWithShadow,IgnoreHeadHiding")


### PR DESCRIPTION
Fixes #150.

Adds an import option to import VRM textures with compression (instead of only using uncompressed, lossless textures).